### PR TITLE
Fixed call of external progress function

### DIFF
--- a/src/Unity.vue
+++ b/src/Unity.vue
@@ -87,7 +87,7 @@
         }
         let params = {}
         if (this.externalProgress) {
-          params.onProgress = UnityProgress
+          params.onProgress = this.externalProgress
         } else {
           params.onProgress = ((gameInstance, progress) => {
             this.loaded = (progress === 1)


### PR DESCRIPTION
The term UnityProgress is not defined anywhere and I guess this line was supposed to call the external progress function which can be passed as a prop to the component. This is now fixed.